### PR TITLE
Fix: Windows compatibility

### DIFF
--- a/imot_bg_crawler/pipelines.py
+++ b/imot_bg_crawler/pipelines.py
@@ -21,7 +21,7 @@ class ImotBgCrawlerPipeline:
 
     @staticmethod
     def get_filename(prefix='result_', suffix=None):
-        return f'{prefix}{datetime.datetime.now().strftime("%d-%m-%Y@%H:%M")}' \
+        return f'{prefix}{datetime.datetime.now().strftime("%d-%m-%Y@%Hh%Mm")}' \
                f'{"_" + suffix if suffix is not None else ""}.json'
 
     @staticmethod

--- a/imot_bg_crawler/pipelines.py
+++ b/imot_bg_crawler/pipelines.py
@@ -67,7 +67,7 @@ class ImotBgCrawlerPipeline:
         filename = self.get_filename(prefix=f'ad-id_{item_id}_')
         filepath = self.get_create_item_dir(item)
         absolute_filename = os.path.join(filepath, filename)
-        with open(absolute_filename, 'w') as file:
+        with open(absolute_filename, 'w', encoding='utf-8') as file:
             file.write(json.dumps(item, ensure_ascii=False).encode('utf8').decode())
             file.close()
 
@@ -96,7 +96,7 @@ class ImotBgCrawlerPipeline:
     def open_spider(self, spider):
         spider_source = spider.allowed_domains[0]
         filename = self.get_all_results_file(spider_source=spider_source)
-        self.results_file = open(filename, 'a')
+        self.results_file = open(filename, 'a', encoding='utf-8')
         self.start_time = datetime.datetime.now()
 
     def process_item(self, item, spider):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ incremental==21.3.0
 itemadapter==0.4.0
 itemloaders==1.0.4
 jmespath==0.10.0
-lxml==4.7.1
+lxml==4.9.4
 parsel==1.6.0
 priority==1.3.0
 Protego==0.1.16
@@ -34,7 +34,7 @@ service-identity==21.1.0
 six==1.16.0
 soupsieve==2.3.1
 text-unidecode==1.3
-Twisted==21.7.0
+Twisted==22.10.0
 typing-extensions==4.0.1
 urllib3==1.26.8
 w3lib==1.22.0


### PR DESCRIPTION
There were some issues with the scraper on Windows
 - Files cannot contain `:` in the name (time format)
 - `libxml2` required C libraries which were not present (dropped in later versions of the lib)
 - `Twisted` had some issues with positional arguments (bumped to nearest major version)